### PR TITLE
feat: Add Word Challenge streak tracking (#9)

### DIFF
--- a/server/src/data/streaks.test.ts
+++ b/server/src/data/streaks.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import {
+  type StreakData,
+  loadStreakData,
+  saveStreakData,
+  updateDailyStreak,
+  updatePracticeStreak,
+  calculateWinRate,
+  getTodayDateString,
+} from "./streaks.js";
+
+const TEST_USER_ID = "test-user-123";
+const STORAGE_DIR = join(process.cwd(), ".data", "streaks");
+
+describe("Streak Tracking", () => {
+  beforeEach(async () => {
+    // Clean up test data before each test
+    try {
+      await fs.rm(STORAGE_DIR, { recursive: true });
+    } catch {
+      // Directory doesn't exist yet
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    try {
+      await fs.rm(STORAGE_DIR, { recursive: true });
+    } catch {
+      // Directory doesn't exist
+    }
+  });
+
+  describe("Date utilities", () => {
+    it("should return today's date in ISO format", () => {
+      const today = getTodayDateString();
+      expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe("Persistence", () => {
+    it("should return default data for new user", async () => {
+      const data = await loadStreakData(TEST_USER_ID);
+
+      expect(data.currentStreak).toBe(0);
+      expect(data.maxStreak).toBe(0);
+      expect(data.lastPlayedDate).toBeNull();
+      expect(data.totalGamesPlayed).toBe(0);
+      expect(data.totalGamesWon).toBe(0);
+    });
+
+    it("should save and load streak data", async () => {
+      const testData: StreakData = {
+        currentStreak: 5,
+        maxStreak: 10,
+        lastPlayedDate: "2024-01-15",
+        totalGamesPlayed: 20,
+        totalGamesWon: 15,
+        dailyGamesPlayed: 10,
+        dailyGamesWon: 8,
+      };
+
+      await saveStreakData(TEST_USER_ID, testData);
+      const loaded = await loadStreakData(TEST_USER_ID);
+
+      expect(loaded).toEqual(testData);
+    });
+
+    it("should handle corrupted data gracefully", async () => {
+      // Write invalid JSON
+      const filePath = join(STORAGE_DIR, `${TEST_USER_ID}.json`);
+      await fs.mkdir(STORAGE_DIR, { recursive: true });
+      await fs.writeFile(filePath, "invalid json", "utf-8");
+
+      const data = await loadStreakData(TEST_USER_ID);
+
+      // Should return default data
+      expect(data.currentStreak).toBe(0);
+      expect(data.maxStreak).toBe(0);
+    });
+  });
+
+  describe("Daily streak updates", () => {
+    it("should start streak at 1 for first daily win", () => {
+      const initialData: StreakData = {
+        currentStreak: 0,
+        maxStreak: 0,
+        lastPlayedDate: null,
+        totalGamesPlayed: 0,
+        totalGamesWon: 0,
+        dailyGamesPlayed: 0,
+        dailyGamesWon: 0,
+      };
+
+      const updated = updateDailyStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(1);
+      expect(updated.maxStreak).toBe(1);
+      expect(updated.dailyGamesPlayed).toBe(1);
+      expect(updated.dailyGamesWon).toBe(1);
+      expect(updated.totalGamesPlayed).toBe(1);
+      expect(updated.totalGamesWon).toBe(1);
+      expect(updated.lastPlayedDate).toBe(getTodayDateString());
+    });
+
+    it("should reset streak to 0 on first daily loss", () => {
+      const initialData: StreakData = {
+        currentStreak: 0,
+        maxStreak: 0,
+        lastPlayedDate: null,
+        totalGamesPlayed: 0,
+        totalGamesWon: 0,
+        dailyGamesPlayed: 0,
+        dailyGamesWon: 0,
+      };
+
+      const updated = updateDailyStreak(initialData, false);
+
+      expect(updated.currentStreak).toBe(0);
+      expect(updated.maxStreak).toBe(0);
+      expect(updated.dailyGamesPlayed).toBe(1);
+      expect(updated.dailyGamesWon).toBe(0);
+      expect(updated.totalGamesPlayed).toBe(1);
+      expect(updated.totalGamesWon).toBe(0);
+    });
+
+    it("should increment streak on consecutive daily win", () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+      const initialData: StreakData = {
+        currentStreak: 3,
+        maxStreak: 5,
+        lastPlayedDate: yesterdayStr,
+        totalGamesPlayed: 5,
+        totalGamesWon: 4,
+        dailyGamesPlayed: 5,
+        dailyGamesWon: 4,
+      };
+
+      const updated = updateDailyStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(4);
+      expect(updated.maxStreak).toBe(5); // Should not update (4 < 5)
+      expect(updated.dailyGamesPlayed).toBe(6);
+      expect(updated.dailyGamesWon).toBe(5);
+    });
+
+    it("should update max streak when current exceeds it", () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+      const initialData: StreakData = {
+        currentStreak: 5,
+        maxStreak: 5,
+        lastPlayedDate: yesterdayStr,
+        totalGamesPlayed: 5,
+        totalGamesWon: 5,
+        dailyGamesPlayed: 5,
+        dailyGamesWon: 5,
+      };
+
+      const updated = updateDailyStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(6);
+      expect(updated.maxStreak).toBe(6);
+    });
+
+    it("should reset streak when days are skipped", () => {
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      const threeDaysAgoStr = threeDaysAgo.toISOString().split("T")[0];
+
+      const initialData: StreakData = {
+        currentStreak: 10,
+        maxStreak: 10,
+        lastPlayedDate: threeDaysAgoStr,
+        totalGamesPlayed: 10,
+        totalGamesWon: 10,
+        dailyGamesPlayed: 10,
+        dailyGamesWon: 10,
+      };
+
+      const updated = updateDailyStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(1);
+      expect(updated.maxStreak).toBe(10); // Max should not change
+    });
+
+    it("should reset streak to 0 on consecutive day loss", () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+      const initialData: StreakData = {
+        currentStreak: 5,
+        maxStreak: 8,
+        lastPlayedDate: yesterdayStr,
+        totalGamesPlayed: 10,
+        totalGamesWon: 8,
+        dailyGamesPlayed: 10,
+        dailyGamesWon: 8,
+      };
+
+      const updated = updateDailyStreak(initialData, false);
+
+      expect(updated.currentStreak).toBe(0);
+      expect(updated.maxStreak).toBe(8); // Max should not change
+      expect(updated.dailyGamesPlayed).toBe(11);
+      expect(updated.dailyGamesWon).toBe(8);
+    });
+
+    it("should not update streak if already played today", () => {
+      const today = getTodayDateString();
+
+      const initialData: StreakData = {
+        currentStreak: 3,
+        maxStreak: 5,
+        lastPlayedDate: today,
+        totalGamesPlayed: 5,
+        totalGamesWon: 4,
+        dailyGamesPlayed: 5,
+        dailyGamesWon: 4,
+      };
+
+      const updated = updateDailyStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(3); // Should not change
+      expect(updated.dailyGamesPlayed).toBe(6); // But stats should update
+      expect(updated.dailyGamesWon).toBe(5);
+    });
+  });
+
+  describe("Practice game updates", () => {
+    it("should update stats but not streak on practice win", () => {
+      const initialData: StreakData = {
+        currentStreak: 5,
+        maxStreak: 10,
+        lastPlayedDate: "2024-01-15",
+        totalGamesPlayed: 20,
+        totalGamesWon: 15,
+        dailyGamesPlayed: 10,
+        dailyGamesWon: 8,
+      };
+
+      const updated = updatePracticeStreak(initialData, true);
+
+      expect(updated.currentStreak).toBe(5); // Unchanged
+      expect(updated.maxStreak).toBe(10); // Unchanged
+      expect(updated.lastPlayedDate).toBe("2024-01-15"); // Unchanged
+      expect(updated.dailyGamesPlayed).toBe(10); // Unchanged
+      expect(updated.dailyGamesWon).toBe(8); // Unchanged
+      expect(updated.totalGamesPlayed).toBe(21);
+      expect(updated.totalGamesWon).toBe(16);
+    });
+
+    it("should update stats but not streak on practice loss", () => {
+      const initialData: StreakData = {
+        currentStreak: 5,
+        maxStreak: 10,
+        lastPlayedDate: "2024-01-15",
+        totalGamesPlayed: 20,
+        totalGamesWon: 15,
+        dailyGamesPlayed: 10,
+        dailyGamesWon: 8,
+      };
+
+      const updated = updatePracticeStreak(initialData, false);
+
+      expect(updated.currentStreak).toBe(5); // Unchanged
+      expect(updated.totalGamesPlayed).toBe(21);
+      expect(updated.totalGamesWon).toBe(15); // Unchanged
+    });
+  });
+
+  describe("Win rate calculation", () => {
+    it("should return 0 for no games played", () => {
+      const data: StreakData = {
+        currentStreak: 0,
+        maxStreak: 0,
+        lastPlayedDate: null,
+        totalGamesPlayed: 0,
+        totalGamesWon: 0,
+        dailyGamesPlayed: 0,
+        dailyGamesWon: 0,
+      };
+
+      expect(calculateWinRate(data)).toBe(0);
+    });
+
+    it("should calculate win rate correctly", () => {
+      const data: StreakData = {
+        currentStreak: 0,
+        maxStreak: 0,
+        lastPlayedDate: null,
+        totalGamesPlayed: 20,
+        totalGamesWon: 15,
+        dailyGamesPlayed: 0,
+        dailyGamesWon: 0,
+      };
+
+      expect(calculateWinRate(data)).toBe(75);
+    });
+
+    it("should round win rate to nearest integer", () => {
+      const data: StreakData = {
+        currentStreak: 0,
+        maxStreak: 0,
+        lastPlayedDate: null,
+        totalGamesPlayed: 3,
+        totalGamesWon: 2,
+        dailyGamesPlayed: 0,
+        dailyGamesWon: 0,
+      };
+
+      expect(calculateWinRate(data)).toBe(67); // 66.666... rounds to 67
+    });
+  });
+});

--- a/server/src/data/streaks.ts
+++ b/server/src/data/streaks.ts
@@ -1,0 +1,187 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * User streak data for Word Challenge game.
+ */
+export interface StreakData {
+  /** Current consecutive daily wins */
+  currentStreak: number;
+  /** Maximum streak achieved */
+  maxStreak: number;
+  /** Last date a daily game was played (ISO date string) */
+  lastPlayedDate: string | null;
+  /** Total games played (daily + practice) */
+  totalGamesPlayed: number;
+  /** Total games won */
+  totalGamesWon: number;
+  /** Total daily games played */
+  dailyGamesPlayed: number;
+  /** Total daily games won */
+  dailyGamesWon: number;
+}
+
+/**
+ * Default streak data for new users.
+ */
+const DEFAULT_STREAK_DATA: StreakData = {
+  currentStreak: 0,
+  maxStreak: 0,
+  lastPlayedDate: null,
+  totalGamesPlayed: 0,
+  totalGamesWon: 0,
+  dailyGamesPlayed: 0,
+  dailyGamesWon: 0,
+};
+
+/**
+ * Storage directory for streak data.
+ */
+const STORAGE_DIR = join(process.cwd(), ".data", "streaks");
+
+/**
+ * Get the file path for a user's streak data.
+ */
+function getUserStreakPath(userId: string): string {
+  return join(STORAGE_DIR, `${userId}.json`);
+}
+
+/**
+ * Ensure the storage directory exists.
+ */
+async function ensureStorageDir(): Promise<void> {
+  try {
+    await fs.mkdir(STORAGE_DIR, { recursive: true });
+  } catch (error) {
+    console.error("Failed to create storage directory:", error);
+  }
+}
+
+/**
+ * Load streak data for a user.
+ * Returns default data if user has no saved data.
+ */
+export async function loadStreakData(userId: string): Promise<StreakData> {
+  try {
+    const filePath = getUserStreakPath(userId);
+    const data = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(data) as StreakData;
+  } catch (error) {
+    // File doesn't exist or is invalid - return defaults
+    return { ...DEFAULT_STREAK_DATA };
+  }
+}
+
+/**
+ * Save streak data for a user.
+ */
+export async function saveStreakData(
+  userId: string,
+  data: StreakData
+): Promise<void> {
+  try {
+    await ensureStorageDir();
+    const filePath = getUserStreakPath(userId);
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
+  } catch (error) {
+    console.error("Failed to save streak data:", error);
+    throw new Error("Failed to save streak data");
+  }
+}
+
+/**
+ * Get today's date as an ISO date string (YYYY-MM-DD).
+ */
+export function getTodayDateString(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+/**
+ * Calculate days between two ISO date strings.
+ */
+function getDaysDifference(date1: string, date2: string): number {
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  const diffMs = Math.abs(d2.getTime() - d1.getTime());
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Update streak data after a daily game completion.
+ *
+ * @param data - Current streak data
+ * @param won - Whether the game was won
+ * @returns Updated streak data
+ */
+export function updateDailyStreak(data: StreakData, won: boolean): StreakData {
+  const today = getTodayDateString();
+  const lastPlayed = data.lastPlayedDate;
+
+  // Update game counters
+  const updated: StreakData = {
+    ...data,
+    dailyGamesPlayed: data.dailyGamesPlayed + 1,
+    dailyGamesWon: won ? data.dailyGamesWon + 1 : data.dailyGamesWon,
+    totalGamesPlayed: data.totalGamesPlayed + 1,
+    totalGamesWon: won ? data.totalGamesWon + 1 : data.totalGamesWon,
+    lastPlayedDate: today,
+  };
+
+  // Only update streak if game was won
+  if (!won) {
+    updated.currentStreak = 0;
+    return updated;
+  }
+
+  // First daily game ever
+  if (!lastPlayed) {
+    updated.currentStreak = 1;
+    updated.maxStreak = Math.max(1, data.maxStreak);
+    return updated;
+  }
+
+  // Already played today - don't update streak
+  if (lastPlayed === today) {
+    return updated;
+  }
+
+  const daysSinceLastPlayed = getDaysDifference(lastPlayed, today);
+
+  if (daysSinceLastPlayed === 1) {
+    // Consecutive day - increment streak
+    updated.currentStreak = data.currentStreak + 1;
+    updated.maxStreak = Math.max(updated.currentStreak, data.maxStreak);
+  } else {
+    // Skipped days - reset streak
+    updated.currentStreak = 1;
+  }
+
+  return updated;
+}
+
+/**
+ * Update streak data after a practice game completion.
+ * Practice games don't affect streak, only total game stats.
+ *
+ * @param data - Current streak data
+ * @param won - Whether the game was won
+ * @returns Updated streak data
+ */
+export function updatePracticeStreak(
+  data: StreakData,
+  won: boolean
+): StreakData {
+  return {
+    ...data,
+    totalGamesPlayed: data.totalGamesPlayed + 1,
+    totalGamesWon: won ? data.totalGamesWon + 1 : data.totalGamesWon,
+  };
+}
+
+/**
+ * Calculate win rate percentage.
+ */
+export function calculateWinRate(data: StreakData): number {
+  if (data.totalGamesPlayed === 0) return 0;
+  return Math.round((data.totalGamesWon / data.totalGamesPlayed) * 100);
+}


### PR DESCRIPTION
## Summary

Implements complete streak tracking and persistence system for Word Challenge game.

## Task: #9 - Add Word Challenge streak tracking

Part of Epic #4 (Game 1: Word Challenge)

## Implementation Completed

✅ Streak data model designed
  - Current streak, max streak tracking
  - Last played date for consecutive day detection
  - Total games played/won (daily + practice)
  - Daily-specific game stats
✅ Persistence layer implemented
  - File-based JSON storage in .data/streaks/
  - loadStreakData, saveStreakData functions
  - Graceful handling of corrupted/missing data
✅ Streak logic implemented
  - updateDailyStreak: Consecutive day detection, streak reset
  - updatePracticeStreak: Stats only (doesn't affect daily streak)
  - calculateWinRate: Win percentage calculation
✅ MCP tools updated
  - start_word_challenge: Loads and returns streak data
  - check_word_guess: Updates streak when game completes
  - GameSession interface tracks mode and userId
✅ 16 comprehensive streak tests (all passing)
✅ All 85 tests passing across entire codebase
✅ TypeScript strict mode compilation clean

## Test Results

```
✓ src/data/streaks.test.ts  (16 tests) 23ms
✓ src/index.test.ts  (14 tests) 5ms
✓ src/games/wordChallenge.test.ts  (32 tests) 11ms
✓ src/data/wordLists.test.ts  (23 tests) 15ms

Test Files  4 passed (4)
     Tests  85 passed (85)
```

## Acceptance Criteria - All Met ✅

✅ Streak increments on consecutive daily wins
✅ Streak resets when daily word is skipped  
✅ Streak persists across sessions (file-based storage)
✅ Practice mode does not affect daily streak
✅ Max streak tracked correctly
✅ Stats (total games, win rate) calculated correctly
✅ Widget receives current streak data
✅ Tests cover all streak scenarios

## Files Modified

- `server/src/data/streaks.ts` - New streak data model and persistence
- `server/src/data/streaks.test.ts` - New comprehensive test suite
- `server/src/index.ts` - Integrate streak tracking into MCP tools

---

**Status:** ✅ Complete - Ready for review and merge